### PR TITLE
Properly exit test script on failure and fix deprecations

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -e
+
 echo "Initializing test environment ..."
 . ./env
 

--- a/src/pytestshot/__init__.py
+++ b/src/pytestshot/__init__.py
@@ -20,8 +20,9 @@ from gi.repository import GObject
 from gi.repository import Gtk
 
 
-GLib.threads_init()
-GObject.threads_init()
+if GLib.glib_version < (3, 10):
+    GLib.threads_init()
+    GObject.threads_init()
 
 
 TESTS_DATA_DIR = os.getenv(

--- a/tests/basic_test.py
+++ b/tests/basic_test.py
@@ -13,7 +13,7 @@ import pytestshot
 class GtkWinInstance(object):
     def start(self):
         self.window = Gtk.Window()
-        self.button = Gtk.Button("pouet")
+        self.button = Gtk.Button.new_with_label("pouet")
         self.window.add(self.button)
         self.window.show_all()
         self.window.set_size_request(640, 480)


### PR DESCRIPTION
`run_tests.sh` currently ignores any errors in the test and returns a 0 exit code when it should fail.

That being said, the tests do not pass. They simply get stuck in a deadlock. I don't really understand why threads are even needed, for the tests at least. I have a [branch here](https://github.com/QuLogic/pytestshot/tree/threadless) that doesn't use them, but I'm not sure what the rationale behind using them was, so I'm not sure if that makes sense.